### PR TITLE
Optimize DPO recipe - precomputing reference model log probabilites

### DIFF
--- a/recipes/configs/llama3_1/8B_lora_dpo_precompute.yaml
+++ b/recipes/configs/llama3_1/8B_lora_dpo_precompute.yaml
@@ -1,0 +1,96 @@
+# Config for multi-device LoRA DPO alignment in lora_dpo_distributed.py
+# using a Llama2 7B model
+#
+# This config assumes that you've run the following command before launching
+# this run:
+#   tune download meta-llama/Meta-Llama-3.1-8B-Instruct --output-dir /tmp/Meta-Llama-3.1-8B-Instruct --ignore-patterns "original/consolidated.00.pth"
+#
+# To launch on 2 devices, run the following command from root:
+#   tune run --nnodes 1 --nproc_per_node 2 lora_dpo_distributed --config llama3_1/8B_lora_dpo
+#
+# You can add specific overrides through the command line. For example
+# to override the checkpointer directory while launching training
+# you can run:
+#   tune run --nnodes 1 --nproc_per_node 2 lora_dpo_distributed --config llama3_1/8B_lora_dpo checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
+#
+# This config works best when the model is being fine-tuned on 2+ GPUs.
+# For single device LoRA DPO alignment please use  llama3_1/8B_lora_dpo_single_device
+
+output_dir: /tmp/torchtune/llama3_1_8B/lora_dpo # /tmp may be deleted by your system. Change it to your preference.
+
+# Model Arguments
+model:
+  _component_: torchtune.models.llama3_1.lora_llama3_1_8b
+  lora_attn_modules: ['q_proj', 'v_proj', 'output_proj']
+  apply_lora_to_mlp: True
+  apply_lora_to_output: False
+  lora_rank: 8  # higher increases accuracy and memory
+  lora_alpha: 16  # usually alpha=2*rank
+  lora_dropout: 0.0
+
+# Tokenizer
+tokenizer:
+  _component_: torchtune.models.llama3.llama3_tokenizer
+  path: /tmp/Meta-Llama-3.1-8B-Instruct/original/tokenizer.model
+  max_seq_len: 1024 # higher increases memory
+
+checkpointer:
+  _component_: torchtune.training.FullModelHFCheckpointer
+  checkpoint_dir: /tmp/Meta-Llama-3.1-8B-Instruct/
+  checkpoint_files: [
+    model-00001-of-00004.safetensors,
+    model-00002-of-00004.safetensors,
+    model-00003-of-00004.safetensors,
+    model-00004-of-00004.safetensors
+  ]
+  recipe_checkpoint: null
+  output_dir: ${output_dir}
+  model_type: LLAMA3
+resume_from_checkpoint: False
+save_adapter_weights_only: False
+
+# Dataset and Sampler
+dataset:
+  _component_: torchtune.datasets.stack_exchange_paired_dataset
+seed: null
+shuffle: True
+batch_size: 4
+
+# Optimizer and Scheduler
+optimizer:
+  _component_: torch.optim.AdamW
+  fused: True
+  weight_decay: 0.05
+  lr: 5e-4
+lr_scheduler:
+  _component_: torchtune.training.lr_schedulers.get_cosine_schedule_with_warmup
+  num_warmup_steps: 100
+
+loss:
+  _component_: torchtune.rlhf.loss.DPOLoss
+  beta: 0.1
+  label_smoothing: 0
+
+# Training
+epochs: 1
+max_steps_per_epoch: 1000
+gradient_accumulation_steps: 8  # Use to increase effective batch size
+compile: False  # torch.compile the model + loss, True increases speed + decreases memory
+
+# Logging
+metric_logger:
+  _component_: torchtune.training.metric_logging.DiskLogger
+  log_dir: ${output_dir}/logs
+log_every_n_steps: 1
+log_peak_memory_stats: True
+
+# Environment
+device: cuda
+dtype: bf16
+
+# Memory management
+enable_activation_checkpointing: True  # True reduces memory
+enable_activation_offloading: False  # True reduces memory
+
+precompute_ref_log_probs: True # Flag to enable precomputation of reference log probabilities
+debug_sample_size: 100 # Size of the sample to use for debugging purposes. Specify None or remove the line to disable.

--- a/recipes/lora_dpo_distributed.py
+++ b/recipes/lora_dpo_distributed.py
@@ -33,6 +33,7 @@ from torchtune.modules.peft import (
     validate_missing_and_unexpected_for_lora,
 )
 from torchtune.recipe_interfaces import FTRecipeInterface
+from torchtune.datasets._preference import CustomPreferenceDataset
 from tqdm import tqdm
 
 log = utils.get_logger("DEBUG")
@@ -180,6 +181,12 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
         self._resume_from_checkpoint = cfg.resume_from_checkpoint
         self._save_adapter_weights_only = cfg.get("save_adapter_weights_only", False)
         self._gradient_accumulation_steps = cfg.gradient_accumulation_steps
+
+        # Add flags to track precomputed ref probabilities
+        self.precompute_ref_log_probs = cfg.get("precompute_ref_log_probs", False)
+        self._precomputed_train_ref_log_probs = False
+
+        self.debug_sample_size = cfg.get("debug_sample_size", None)
 
     def load_checkpoint(self, cfg_checkpointer: DictConfig) -> Dict[str, Any]:
         """
@@ -495,14 +502,38 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
         """
         world_size, rank = utils.get_world_size_and_rank()
 
+        # Create PreferenceDataset
         if isinstance(cfg_dataset, ListConfig):
             datasets = [
-                config.instantiate(single_cfg_dataset, tokenizer=self._tokenizer)
+                CustomPreferenceDataset(
+                    config.instantiate(single_cfg_dataset, tokenizer=self._tokenizer),  
+                )
                 for single_cfg_dataset in cfg_dataset
             ]
             ds = ConcatDataset(datasets=datasets)
         else:
-            ds = config.instantiate(cfg_dataset, tokenizer=self._tokenizer)
+            ds = CustomPreferenceDataset(
+                config.instantiate(cfg_dataset, tokenizer=self._tokenizer)
+            )
+
+        # Take a small sample for debugging if debug_sample_size is set
+        if self.debug_sample_size is not None:
+            if self._is_rank_zero:
+                log.warning(
+                    f"Running in debug mode with sample size {self.debug_sample_size}. "
+                    "This should only be used for debugging purposes!"
+                )
+            # Take first debug_sample_size examples
+            if isinstance(ds, ConcatDataset):
+                # For ConcatDataset, take samples from first dataset
+                ds.datasets[0] = ds.datasets[0].select(range(min(self.debug_sample_size, len(ds.datasets[0]))))
+            else:
+                # Update this line to handle datasets without a 'select' method
+                ds = torch.utils.data.Subset(ds, range(min(self.debug_sample_size, len(ds))))
+
+        # Precompute reference probabilities if enabled
+        if self.precompute_ref_log_probs and not self._precomputed_train_ref_log_probs:
+            self.precompute_reference_log_probs(ds, batch_size, world_size, rank)
 
         sampler = DistributedSampler(
             ds, num_replicas=world_size, rank=rank, shuffle=shuffle, seed=0
@@ -524,6 +555,73 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
         utils.log_rank_zero(log, "Dataset and Sampler are initialized.")
 
         return sampler, dataloader
+
+    def precompute_reference_log_probs(
+        self,
+        ds: torch.utils.data.Dataset,
+        batch_size: int,
+        world_size: int,
+        rank: int,
+    ) -> None:
+        """
+        Precompute reference model log probabilities for the dataset.
+        
+        Args:
+            ds: Dataset to precompute probabilities for
+            batch_size: Batch size for precomputation
+            world_size: Number of distributed processes
+            rank: Current process rank
+        """
+        utils.log_rank_zero(log, "Precomputing reference log probabilities for training dataset...")
+        
+        # Create temporary dataloader for precomputation
+        temp_sampler = DistributedSampler(ds, num_replicas=world_size, rank=rank, shuffle=False)
+        temp_dataloader = DataLoader(
+            dataset=ds,
+            batch_size=batch_size,
+            sampler=temp_sampler,
+            drop_last=False,
+            collate_fn=partial(
+                padded_collate_dpo,
+                padding_idx=self._tokenizer.pad_id,
+                ignore_idx=CROSS_ENTROPY_IGNORE_IDX,
+            ),
+        )
+
+        ref_chosen_logps = []
+        ref_rejected_logps = []
+        for batch in tqdm(temp_dataloader, desc="Computing reference log probs", disable=not self._is_rank_zero):
+            with torch.no_grad(), disable_adapter(self._model):
+                chosen_log_probs, rejected_log_probs, _, _ = self.concatenated_forward(self._model, batch)
+                ref_chosen_logps.append(chosen_log_probs.cpu())
+                ref_rejected_logps.append(rejected_log_probs.cpu())
+
+            # Clear cache to avoid OOM
+            torch.cuda.empty_cache()
+
+        # Gather and process results
+        all_ref_chosen_logps = torch.cat(ref_chosen_logps)
+        all_ref_rejected_logps = torch.cat(ref_rejected_logps)
+
+        # Gather across all ranks
+        gathered_chosen = [torch.zeros_like(all_ref_chosen_logps) for _ in range(world_size)]
+        gathered_rejected = [torch.zeros_like(all_ref_rejected_logps) for _ in range(world_size)]
+        
+        torch.distributed.all_gather(gathered_chosen, all_ref_chosen_logps)
+        torch.distributed.all_gather(gathered_rejected, all_ref_rejected_logps)
+
+        all_ref_chosen_logps = torch.cat(gathered_chosen)
+        all_ref_rejected_logps = torch.cat(gathered_rejected)
+        
+        # Add reference log probs to the dataset
+        target_dataset = ds.dataset if isinstance(ds, torch.utils.data.Subset) else ds
+        if isinstance(target_dataset, ConcatDataset):
+            target_dataset.datasets[0].add_reference_log_probs(all_ref_chosen_logps, all_ref_rejected_logps)
+        else:
+            target_dataset.add_reference_log_probs(all_ref_chosen_logps, all_ref_rejected_logps)
+
+        self._precomputed_train_ref_log_probs = True
+        torch.distributed.barrier()
 
     def save_checkpoint(
         self,
@@ -627,7 +725,7 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
         Returns:
             Tuple of chosen log probs, rejected log probs, chosen logits, rejected logits.
         """
-        concatenated_input_ids, concatenated_labels = batch
+        concatenated_input_ids, concatenated_labels, *_ = batch
         concatenated_input_ids = concatenated_input_ids.to(self._device)
         concatenated_labels = concatenated_labels.to(self._device)
 
@@ -696,13 +794,21 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
                 # deleting logits here helps reduce (peak) memory usage - we only need them for metric logging
                 del policy_chosen_logits, policy_rejected_logits
 
-                with torch.no_grad(), disable_adapter(self._model):
-                    (
-                        reference_chosen_log_probs,
-                        reference_rejected_log_probs,
-                        _,
-                        _,
-                    ) = self.concatenated_forward(self._model, batch)
+                # Use precomputed ref probabilities from dataset if available
+                if self.precompute_ref_log_probs:
+                    # Get reference log probs directly from the batch
+                    _, _, reference_chosen_log_probs, reference_rejected_log_probs = batch
+                    reference_chosen_log_probs = reference_chosen_log_probs.to(self._device)
+                    reference_rejected_log_probs = reference_rejected_log_probs.to(self._device)
+                else:
+                    with torch.no_grad(), disable_adapter(self._model):
+                        (
+                            reference_chosen_log_probs,
+                            reference_rejected_log_probs,
+                            _,
+                            _,
+                        ) = self.concatenated_forward(self._model, batch)
+
                 loss, chosen_rewards, rejected_rewards = self._loss_fn(
                     policy_chosen_log_probs,
                     policy_rejected_log_probs,

--- a/tests/torchtune/datasets/test_preference_dataset.py
+++ b/tests/torchtune/datasets/test_preference_dataset.py
@@ -8,11 +8,12 @@ from typing import Any, Mapping
 from unittest import mock
 
 import pytest
+import torch
 from tests.common import ASSETS
 from tests.test_utils import DummyTokenizer
 from torchtune.data import Message
 from torchtune.data._common import CROSS_ENTROPY_IGNORE_IDX
-from torchtune.datasets._preference import preference_dataset, PreferenceDataset
+from torchtune.datasets._preference import preference_dataset, PreferenceDataset, CustomPreferenceDataset
 from torchtune.modules.transforms import Transform
 
 
@@ -169,3 +170,54 @@ class TestPreferenceDataset:
                 split="train",
                 packed=True,
             )
+
+class TestCustomPreferenceDataset:
+    @pytest.fixture
+    def base_dataset(self):
+        # Mocking a base PreferenceDataset
+        mock_dataset = mock.MagicMock(spec=PreferenceDataset)
+        mock_dataset.__len__.return_value = 1
+        mock_dataset.__getitem__.return_value = {
+            "chosen_input_ids": [0, 1, 2],
+            "chosen_labels": [0, 1, 2],
+            "rejected_input_ids": [3, 4, 5],
+            "rejected_labels": [3, 4, 5],
+        }
+        return mock_dataset
+
+    def test_custom_preference_dataset(self, base_dataset):
+        custom_dataset = CustomPreferenceDataset(base_dataset=base_dataset)
+
+        assert len(custom_dataset) == 1
+        expected_keys = [
+            "chosen_input_ids",
+            "chosen_labels",
+            "rejected_input_ids",
+            "rejected_labels",
+        ]
+        assert set(custom_dataset[0].keys()) == set(expected_keys)
+        assert len(custom_dataset[0].keys()) == 4
+
+    def test_add_reference_log_probs(self, base_dataset):
+        custom_dataset = CustomPreferenceDataset(base_dataset=base_dataset)
+
+        ref_chosen_logps = torch.tensor([0.1, 0.2, 0.3])
+        ref_rejected_logps = torch.tensor([0.4, 0.5, 0.6])
+
+        custom_dataset.add_reference_log_probs(ref_chosen_logps, ref_rejected_logps)
+
+        expected_keys = [
+            "chosen_input_ids",
+            "chosen_labels",
+            "rejected_input_ids",
+            "rejected_labels",
+            "ref_chosen_logps",
+            "ref_rejected_logps",
+        ]
+        assert set(custom_dataset[0].keys()) == set(expected_keys)
+        assert len(custom_dataset[0].keys()) == 6
+
+        for i in range(len(custom_dataset)):
+            item = custom_dataset[i]
+            assert torch.equal(item['ref_chosen_logps'], ref_chosen_logps[i])
+            assert torch.equal(item['ref_rejected_logps'], ref_rejected_logps[i]) 

--- a/torchtune/datasets/_preference.py
+++ b/torchtune/datasets/_preference.py
@@ -7,6 +7,7 @@
 from typing import Any, Callable, Dict, List, Mapping, Optional
 
 import numpy as np
+import torch
 from datasets import load_dataset
 from torch.utils.data import Dataset
 
@@ -158,6 +159,49 @@ class PreferenceDataset(Dataset):
         )
 
         return tokenized_dict
+    
+class CustomPreferenceDataset(Dataset):
+    """
+    A dataset class for preference data that can store precomputed reference log probabilities.
+    """
+    def __init__(self, 
+            base_dataset: PreferenceDataset,
+        ) -> None:
+        """
+        Initialize the preference dataset.
+        
+        Args:
+            base_dataset: The underlying dataset containing preference pairs
+        """
+        self.base_dataset = base_dataset
+        self.ref_chosen_logps: Optional[torch.Tensor] = None
+        self.ref_rejected_logps: Optional[torch.Tensor] = None
+
+    def __len__(self):
+        return len(self.base_dataset)
+
+    def __getitem__(self, idx: int) -> Dict:
+        item = self.base_dataset[idx]
+
+        if self.ref_chosen_logps is not None:
+            item['ref_chosen_logps'] = self.ref_chosen_logps[idx]
+        if self.ref_rejected_logps is not None:
+            item['ref_rejected_logps'] = self.ref_rejected_logps[idx]
+            
+        return item
+
+    def add_reference_log_probs(self, 
+                              ref_chosen_logps: torch.Tensor, 
+                              ref_rejected_logps: torch.Tensor) -> None:
+        """
+        Add precomputed reference log probabilities to the dataset.
+        
+        Args:
+            ref_chosen_logps: Log probabilities for chosen responses
+            ref_rejected_logps: Log probabilities for rejected responses
+        """
+        self.ref_chosen_logps = ref_chosen_logps
+        self.ref_rejected_logps = ref_rejected_logps 
 
 
 def preference_dataset(


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [x] add a new feature
- [ ] fix a bug
- [x] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
What are the changes made in this PR?
The primary purpose of this PR is to add support for precomputing reference log probabilities when using DPO. This would make the overall training faster by removing the redundant computation across epochs. 
- `CustomPreferenceDataset` - This file is a modification of the Preference Dataset that allows the storage of the reference log probabilities along with the data. Every get-item call would return a dictionary of input_ids, labels and the reference model chosen and rejected log probabilities.
- `padded_collate_dpo` - Modified this function to return the precomputed log probabilities too along with the inputs and labels.
- `lora_dpo_distributed` - Added the support to precompute the reference log probabilities during data setup. For computing losses, the batch item can return the precomputed values saving compute. Implementation is inspired from the [Hugging Face trl repository DPO implementation](https://github.com/huggingface/trl/blob/763738f457f283270772ac9bd5b3e4027fd424d5/trl/trainer/dpo_trainer.py#L708).

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [x] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [x] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [x] manually run any new or modified recipes with sufficient proof of correctness
- [x] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [ ] I did not change any public API
- [ ] I have added an example to docs or docstrings
